### PR TITLE
Added custom bootstrap bower component and updated gitignore to ignor…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/bower_components/
+/client/node_modules/
+/client/build/
+npm-debug.log

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,19 @@
+{
+  "name": "skeleton2",
+  "version": "0.0.0",
+  "homepage": "https://github.com/Pixelmixer/skeleton2",
+  "authors": [
+    "Dustin Sparks <pixelmixer@gmail.com>"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "devDependencies": {
+    "custom-bootstrap": "./client/src/bower_components/custom-bootstrap"
+  }
+}

--- a/client/package.json
+++ b/client/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Project Name Here",
+  "name": "skeleton",
   "version": "1.0.0",
   "description": "Description of this project",
   "main": "index.js",

--- a/client/src/bower_components/custom-bootstrap/assets/stylesheets/_bootstrap-custom.scss
+++ b/client/src/bower_components/custom-bootstrap/assets/stylesheets/_bootstrap-custom.scss
@@ -1,0 +1,63 @@
+/*!
+ * Adapted from Bootstrap v3.3.5 (http://getbootstrap.com)
+ * Copyright 2011-2015 Twitter, Inc.
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+ * Adapted by Dustin Sparks (pixelmixer@gmail.com)
+ *
+ * Usage: Add or remove bootstrap components that you would like to use in your project
+ * by commenting, uncommenting or manually adding imports.
+ */
+
+// Custom bootstrap variable overrides
+@import "_variables.scss";
+
+// Core variables and mixins
+@import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/variables";
+@import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/mixins";
+
+// Reset and dependencies
+// @import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/normalize";
+// @import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/print";
+// @import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/glyphicons";
+
+// Core CSS
+// @import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/scaffolding";
+// @import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/type";
+// @import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/code";
+@import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/grid";
+// @import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/tables";
+// @import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/forms";
+// @import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/buttons";
+
+// Components
+// @import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/component-animations";
+// @import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/dropdowns";
+// @import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/button-groups";
+// @import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/input-groups";
+// @import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/navs";
+// @import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/navbar";
+// @import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/breadcrumbs";
+// @import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/pagination";
+// @import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/pager";
+// @import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/labels";
+// @import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/badges";
+// @import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/jumbotron";
+// @import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/thumbnails";
+// @import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/alerts";
+// @import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/progress-bars";
+// @import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/media";
+// @import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/list-group";
+// @import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/panels";
+// @import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/responsive-embed";
+// @import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/wells";
+// @import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/close";
+
+// Components w/ JavaScript
+// @import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/modals";
+// @import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/tooltip";
+// @import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/popovers";
+// @import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/carousel";
+
+// Utility classes
+// @import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/utilities";
+// @import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/responsive-utilities";

--- a/client/src/bower_components/custom-bootstrap/assets/stylesheets/_variables.scss
+++ b/client/src/bower_components/custom-bootstrap/assets/stylesheets/_variables.scss
@@ -1,0 +1,9 @@
+/*!
+ * Custom bootstrap variable overrides.
+ * (For configurable variables see bower_components/bootstrap-sass-official/assets/stylesheets/bootstrap/variables)
+ */
+ 
+$screen-md: 1024px;
+$screen-lg: 1600px;
+
+@import "../../../bootstrap-sass-official/assets/stylesheets/bootstrap/variables";

--- a/client/src/bower_components/custom-bootstrap/bower.json
+++ b/client/src/bower_components/custom-bootstrap/bower.json
@@ -1,0 +1,26 @@
+{
+  "name": "custom-bootstrap",
+  "version": "0.0.2",
+  "homepage": "https://github.com/Pixelmixer/skeleton2",
+  "authors": [
+    "Dustin Sparks <pixelmixer@gmail.com>"
+  ],
+  "description": "Custom package to import just the necessary components from bootstrap-sass-official.",
+  "moduleType": [
+    "globals"
+  ],
+  "keywords": [
+    "Bootstrap"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "bootstrap-sass-official": "~3.3.5"
+  }
+}

--- a/client/src/scss/style.scss
+++ b/client/src/scss/style.scss
@@ -1,15 +1,24 @@
 // style.scss - Usage: aggregation of core, third party and component styles
 
+//
+// Load third party css (bower and otherwise):
+// --------------------------------------------------
+// non-bower
+// @import './lib/foo-component.scss';
+// bower
+// @import '../bower_components/owlcarousel2/src/owl.carousel.scss';
+@import '../bower_components/custom-bootstrap/assets/stylesheets/bootstrap-custom';
 
 //
 // Global sass vars
 // --------------------------------------------------
 
-$mobile : 767px;
-$portrait : 768px;
-$landscape : 1024px;
-$huge: 1600px;
-
+// Create custom screen query aliases that point to bootstrap variables
+// (Note: These variables are overridden in bower_components/custom-bootstrap/assets/stylesheets/variables)
+$mobile : $screen-xs-max;
+$portrait : $screen-sm;
+$landscape : $screen-md;
+$huge: $screen-lg;
 
 //
 // Load core styles
@@ -21,15 +30,6 @@ $huge: 1600px;
 @import 'forms';
 @import 'layout';
 @import 'base';
-
-//
-// Load third party css (bower and otherwise):
-// --------------------------------------------------
-// non-bower
-// @import './lib/foo-component.scss';
-// bower
-// @import '../bower_components/owlcarousel2/src/owl.carousel.scss';
-
 
 //
 // Load custom component css:


### PR DESCRIPTION
Added custom bootstrap bower component and updated .gitignore to ignore build folders for now.

The bower_components folder inside client/src is to store the local version of the bower component. Running `bower install` will copy the contents of this folder into the primary bower_components folder and install dependencies (currently custom-bootstrap's only dependency is bootstrap-sass-official).