### PR TITLE
Fixed gitignore and bower.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@
 /bower_components/*
 /client/node_modules/
 /client/build/
+/client/src/node_modules/
+/client/src/bower_components/
 npm-debug.log

--- a/client/src/bower.json
+++ b/client/src/bower.json
@@ -15,6 +15,6 @@
     "tests"
   ],
   "dependencies": {
-    "bower-custom-bootstrap" : "git@github.com:vespoli/bower-custom-bootstrap.git"
+    "bower-custom-bootstrap" : "https://github.com/vespoli/bower-custom-bootstrap.git"
   }
 }


### PR DESCRIPTION
Fixed gitignore and bower.json to point to a public path rather than private for custom bootstrap sass